### PR TITLE
Allow mgcv::bam

### DIFF
--- a/DHARMa/R/simulateResiduals.R
+++ b/DHARMa/R/simulateResiduals.R
@@ -203,7 +203,7 @@ simulateResiduals <- function(fittedModel, n = 250, refit = F, integerResponse =
   return(out)
 }
 
-getPossibleModels<-function()c("lm", "glm", "negbin", "lmerMod", "glmerMod", "gam", "glmmTMB") 
+getPossibleModels<-function()c("lm", "glm", "negbin", "lmerMod", "glmerMod", "gam", "bam", "glmmTMB") 
 
 checkModel <- function(fittedModel){
   if(!(class(fittedModel)[1] %in% getPossibleModels())) warning("DHARMa: fittedModel not in class of supported models. Absolutely no guarantee that this will work!")
@@ -215,7 +215,7 @@ checkModel <- function(fittedModel){
 
 getFixedEffects <- function(fittedModel){
   
-  if(class(fittedModel)[1] %in% c("glm", "lm", "gam", "negbin") ){
+  if(class(fittedModel)[1] %in% c("glm", "lm", "gam", "bam", "negbin") ){
     out  = coef(fittedModel)
   } else if(class(fittedModel)[1] %in% c("glmerMod", "lmerMod")){
     out = lme4::fixef(fittedModel)


### PR DESCRIPTION
[`mgcv::bam`](https://stat.ethz.ch/R-manual/R-devel/library/mgcv/html/bam.html) is designed to fit generalized additive models (GAM) to very large data sets, with improved memory consumption and speed. I believe that for all intents and purposes for DHARMa it is compatible to the same extend as `mgcv::gam`. This PR allows `simulateResiduals` to run without error, whereas without it you get the following:

```
Error in getFixedEffects(fittedModel) : 
In addition: Warning message:
In checkModel(fittedModel) :
  DHARMa: fittedModel not in class of supported models. Absolutely no guarantee that this will work!
`