### PR TITLE
add integerResponse families from spaMM

### DIFF
--- a/DHARMa/R/simulateResiduals.R
+++ b/DHARMa/R/simulateResiduals.R
@@ -54,7 +54,7 @@ simulateResiduals <- function(fittedModel, n = 250, refit = F, integerResponse =
   
   family = family(fittedModel)
   if(is.null(integerResponse)){
-    if (family$family %in% c("binomial", "poisson", "quasibinomial", "quasipoisson", "Negative Binom", "nbinom2", "nbinom1", "genpois", "compois", "truncated_poisson", "truncated_nbinom2", "truncated_nbinom1", "betabinomial") | grepl("Negative Binomial",family$family) ) integerResponse = T
+    if (family$family %in% c("binomial", "poisson", "quasibinomial", "quasipoisson", "Negative Binom", "nbinom2", "nbinom1", "genpois", "compois", "truncated_poisson", "truncated_nbinom2", "truncated_nbinom1", "betabinomial", "Poisson", "Tpoisson", "COMPoisson", "negbin", "Tnegbin") | grepl("Negative Binomial",family$family) ) integerResponse = T
     else integerResponse = F
   }
   


### PR DESCRIPTION
Hi Florian,
I think that the Poisson and negative binomial families of spaMM (i.e. `Poisson`, `Tpoisson`, `COMPoisson`, `negbin`, `Tnegbin`) should all be considered as `intergerResponse` in the function `simulateResiduals`.
(cc @f-rousset)