### PR TITLE
Update tests.R

### DIFF
--- a/DHARMa/R/tests.R
+++ b/DHARMa/R/tests.R
@@ -135,7 +135,7 @@ testQuantiles <- function(simulationOutput, predictor = NULL, quantiles = c(0.25
     class(out) = "htest"
 
   } else if(plot == T) {
-    out <- plotResiduals(simulationOutput = simulationOutput, predictor = predictor, quantiles = quantiles, quantreg = TRUE)
+    out <- plotResiduals(simulationOutput = simulationOutput, form = predictor, quantiles = quantiles, quantreg = TRUE)
   }
   return(out)
 }


### PR DESCRIPTION
Hi Florian,

I think there is an issue with the argument naming between `testQuantiles()` and `plotResiduals()`. `plotResiduals()` expects the predictor argument to be called `form`, whereas it is called `predictor` throughout `testQuantiles()`.

If you need more information about the problem or some example to illustrate it, let me know.

Greetings,
Justin