### PR TITLE
Git action

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -6,11 +6,11 @@ on:
       - main
       - master
       - GitAction
+      
   pull_request:
     branches:
       - main
       - master
-      - GitAction
 
 name: R-CMD-check
 
@@ -42,16 +42,16 @@ jobs:
           r-version: ${{ matrix.config.r }}
 
       - uses: r-lib/actions/setup-pandoc@v1
-
+      
       - name: Query dependencies
-        run: | 
+        run: |
           setwd("DHARMa")
           install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), "../.github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), "../.github/R-version")
         shell: Rscript {0}
 
-      - name: Cache R packages
+      - name: Cache R packages 
         if: runner.os != 'Windows'
         uses: actions/cache@v2
         with:
@@ -74,14 +74,6 @@ jobs:
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
-
-      - name: Check
-        env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: |
-          options(crayon.enabled = TRUE)
-          rcmdcheck::rcmdcheck("DHARMa", args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
         
       - name: Check_II
         env:
@@ -91,6 +83,13 @@ jobs:
           rcmdcheck::rcmdcheck("DHARMa", args = c("--no-multiarch", "--no-manual"), error_on = "warning", check_dir = "check")
         shell: Rscript {0}
         
+      - name: Check
+        env:
+          _R_CHECK_CRAN_INCOMING_REMOTE_: false
+          CI: true
+        run: |
+          rcmdcheck::rcmdcheck("DHARMa", args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
+        shell: Rscript {0}
 
       - name: Upload check results
         if: failure()

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - master
+      - GitAction
   pull_request:
     branches:
       - main
       - master
+      - GitAction
 
 name: R-CMD-check
 
@@ -80,6 +82,15 @@ jobs:
           options(crayon.enabled = TRUE)
           rcmdcheck::rcmdcheck("DHARMa", args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
         shell: Rscript {0}
+        
+      - name: Check_II
+        env:
+          _R_CHECK_CRAN_INCOMING_REMOTE_: false
+          CI: true
+        run: |
+          rcmdcheck::rcmdcheck("DHARMa", args = c("--no-multiarch", "--no-manual"), error_on = "warning", check_dir = "check")
+        shell: Rscript {0}
+        
 
       - name: Upload check results
         if: failure()


### PR DESCRIPTION
fiexed the current Issue´s, as well as I added a new check,
check II:  rcmdcheck::rcmdcheck("DHARMa", args = c("--no-multiarch", "--no-manual"), error_on = "warning", check_dir = "check")
which is not dependent on the argument "as-cran" this should be using the testthat files now, and by that do the trick 