### PR TITLE
Corrects very minor typos in documentation for `getQuantile()`

### DIFF
--- a/DHARMa/R/helper.R
+++ b/DHARMa/R/helper.R
@@ -36,7 +36,7 @@ DHARMa.ecdf <- function (x)
 #'
 #' For discrete data, there are two options implemented.
 #'
-#' The current default (available since DHARMa 0.3.1) are probability integral transform (PIT-) residuals (Smith, 1985; Dunn & Smyth, 1996; see also see also Warton, et al., 2017).
+#' The current default (available since DHARMa 0.3.1) are probability integral transform (PIT-) residuals (Smith, 1985; Dunn & Smyth, 1996; see also Warton, et al., 2017).
 #'
 #' Before DHARMa 0.3.1, a different randomization procedure was used, in which the a U(-0.5, 0.5) distribution was added on observations and simulations for discrete distributions. For a completely discrete distribution, the two procedures should deliver equivalent results, but the second method has the disadvantage that a) one has to know if the distribution is discrete (DHARMa tries to recognize this automatically), and b) that it leads to inefficiencies for some distributions such as the Tweedie, which are partly continuous, partly discrete (see e.g. https://github.com/florianhartig/DHARMa/issues/168).
 #' 

--- a/DHARMa/R/helper.R
+++ b/DHARMa/R/helper.R
@@ -38,7 +38,8 @@ DHARMa.ecdf <- function (x)
 #'
 #' The current default (available since DHARMa 0.3.1) are probability integral transform (PIT-) residuals (Smith, 1985; Dunn & Smyth, 1996; see also Warton, et al., 2017).
 #'
-#' Before DHARMa 0.3.1, a different randomization procedure was used, in which the a U(-0.5, 0.5) distribution was added on observations and simulations for discrete distributions. For a completely discrete distribution, the two procedures should deliver equivalent results, but the second method has the disadvantage that a) one has to know if the distribution is discrete (DHARMa tries to recognize this automatically), and b) that it leads to inefficiencies for some distributions such as the Tweedie, which are partly continuous, partly discrete (see e.g. https://github.com/florianhartig/DHARMa/issues/168).
+#' Before DHARMa 0.3.1, a different randomization procedure was used, in which the a U(-0.5, 0.5) distribution was added on observations and simulations for discrete distributions. For a completely discrete distribution, the two procedures should deliver equivalent results, but the second method has the disadvantage that a) one has to know if the distribution is discrete (DHARMa tries to recognize this automatically), and b) that it leads to inefficiencies for some distributions such as the Tweedie, which are partly continuous, partly discrete
+#' (see e.g. [issue #168](https://github.com/florianhartig/DHARMa/issues/168)).
 #' 
 #' **Rotation (optional)**
 #' 

--- a/DHARMa/R/helper.R
+++ b/DHARMa/R/helper.R
@@ -43,7 +43,7 @@ DHARMa.ecdf <- function (x)
 #' 
 #' **Rotation (optional)**
 #' 
-#' The getQuantile function includes an additional option to rotate residuals. The purpose is to de-correlated residuals in case of residual autocorrelation. If the expected residual autocorrelation is known (e.h. when fitting gls type models), it can be provided as a covariance matrix. If that is note the case, the option "estimated" will try to estimate the covariance from the data simulated by the model. Note, however, that this approximation will tend to have considerable error and may be slow to compute for high-dimensional data. 
+#' The getQuantile function includes an additional option to rotate residuals. The purpose is to de-correlated residuals in case of residual autocorrelation. If the expected residual autocorrelation is known (e.g. when fitting gls type models), it can be provided as a covariance matrix. If that is note the case, the option "estimated" will try to estimate the covariance from the data simulated by the model. Note, however, that this approximation will tend to have considerable error and may be slow to compute for high-dimensional data. 
 #'
 #' @references
 #'

--- a/DHARMa/R/helper.R
+++ b/DHARMa/R/helper.R
@@ -38,7 +38,7 @@ DHARMa.ecdf <- function (x)
 #'
 #' The current default (available since DHARMa 0.3.1) are probability integral transform (PIT-) residuals (Smith, 1985; Dunn & Smyth, 1996; see also see also Warton, et al., 2017).
 #'
-#' Before DHARMa 0.3.1, a different randomization procedure was used, in which the a U(-0.5, 0.5) distribution was added on observations and simulations for discrete distributions. For a completely discrete distribution, the two procedures should deliver equivalent results, but the second method has the disadvantage that a) one has to know if the distribution is discrete (DHARMa tries to recognize this automatically), and b) that it leads to inefficiencies for some distributions such as the the Tweedie, which are partly continuous, partly discrete (see e.g. https://github.com/florianhartig/DHARMa/issues/168).
+#' Before DHARMa 0.3.1, a different randomization procedure was used, in which the a U(-0.5, 0.5) distribution was added on observations and simulations for discrete distributions. For a completely discrete distribution, the two procedures should deliver equivalent results, but the second method has the disadvantage that a) one has to know if the distribution is discrete (DHARMa tries to recognize this automatically), and b) that it leads to inefficiencies for some distributions such as the Tweedie, which are partly continuous, partly discrete (see e.g. https://github.com/florianhartig/DHARMa/issues/168).
 #' 
 #' **Rotation (optional)**
 #' 


### PR DESCRIPTION
This pull includes 4 very small changes to the documentation of `getQuantile()`.
Three commits correct typos and one commit attempts to use rmarkdown to
create a link rather than showing users the entire url to the GitHub issue.
When reading the documentation on CRAN it looks like this 
![image](https://user-images.githubusercontent.com/4108564/163249871-d718ea96-c53c-44c9-9334-9561b7246fe9.png)
where the url runs off of the page. I did not actually render the documentation but
I am pretty sure that the proposed change fixes it.

Feel free to close this pull request without merging if you want to fix 
these things on your own time or in a different way.