### PR TITLE
Replace solve with forwardsolve for efficiency

### DIFF
--- a/DHARMa/R/helper.R
+++ b/DHARMa/R/helper.R
@@ -109,8 +109,8 @@ getQuantile <- function(simulations, observed, integerResponse,
       }
       else if(is.matrix(rotation)) L <- t(chol(rotation))
       else stop("DHARMa::getQuantile - wrong argument to rotation parameter.")
-      observed <- solve(L, observed)
-      simulations = apply(simulations, 2, function(a) solve(L, a))
+      observed <- forwardsolve(L, observed)
+      simulations = forwardsolve(L, simulations)
     }
 
     scaledResiduals = rep(NA, n)


### PR DESCRIPTION
This is the biggest bottleneck for rotation from the estimated covariance matrix. It can be fixed with replacing solve with forwardsolve. 

```
> microbenchmark::microbenchmark(forwardsolve(L, observed), solve(L, observed))
Unit: microseconds
                      expr     min        lq       mean   median       uq       max neval cld
 forwardsolve(L, observed)   126.6   216.851   254.7099   244.95   306.55   398.301   100  a 
        solve(L, observed) 42171.4 56948.701 63722.9831 64169.15 73046.40 86447.200   100   b

> tic();apply(simulations, 2, function(a) solve(L, a))->abc;toc()
55.92 sec elapsed

> microbenchmark::microbenchmark(forwardsolve(L, simulations))
Unit: milliseconds
                         expr      min       lq     mean   median       uq      max neval
 forwardsolve(L, simulations) 105.8228 129.4482 142.1354 143.2465 154.4592 178.9723   100
```

Note that it is faster to run 100 evals of the `forwardsolve` compared to one run of `solve`