### PR TITLE
simulateLRT black line

### DIFF
--- a/DHARMa/R/tests.R
+++ b/DHARMa/R/tests.R
@@ -885,7 +885,7 @@ getP <- function(simulated, observed, alternative, plot = FALSE, ...){
   if(alternative == "two.sided") p = min(min(mean(simulated <= observed), mean(simulated >= observed) ) * 2,1)
 
   if(plot == T){
-    hist(simulated, xlim = range(simulated, observed), col = "lightgrey", main = "Distribution of test statistic \n grey = simulated, red = observed", ...)
+    hist(simulated, xlim = range(simulated, observed), col = "lightgrey", main = "Distribution of test statistic \n grey = simulated, red = observed, black = average", ...)
     abline(v = mean(simulated), col = 1, lwd = 2)
     abline(v = observed, col = "red", lwd = 2)
   }


### PR DESCRIPTION
SimulateLRT with `plot = TRUE` plots the average simulated statistic in black. That is great, but it is not documented nor clarified in the plot. This PR adds it to the title of the plot, just as for the observed test statistic.