### PR TITLE
Restore simcodes of glmmTMB (issue #538)

### DIFF
--- a/DHARMa/NEWS.md
+++ b/DHARMa/NEWS.md
@@ -1,5 +1,14 @@
 NOTE: for more news about the package, see https://github.com/florianhartig/DHARMa/releases
 
+# DHARMa 0.5.1
+
+
+## Bugfixes
+
+* Version 0.5.0 was changing the `glmmTMB` model object "simcode" when using simulateResiduals. We fixed this problem by restoring the original simcode to the model object.
+
+
+
 # DHARMa 0.5.0
 
 

--- a/DHARMa/R/compatibility.R
+++ b/DHARMa/R/compatibility.R
@@ -645,13 +645,17 @@ getSimulations.glmmTMB <- function (object, nsim = 1, simulateREs = c("condition
 
   out = NULL
 
-  # fixes #538 (restore simCode of model object)
-  originalSimcodes = sapply(seq_along(object$obj$env$data$terms),
-                             function(i) object$obj$env$data$terms[[i]]$simCode)
+  # fixes #538 (restore simcodes of model object)
+  nSimcodes = length(object$obj$env$data$terms)
+  originalSimcodes = vector("list", nSimcodes)
 
-  on.exit(for (i in seq_along(object$obj$env$data$terms)) {
-      object$obj$env$data$terms[[i]]$simCode = originalSimcodes[i]
-    })
+  for(i in seq_len(nSimcodes)) {
+    originalSimcodes[[i]] = object$obj$env$data$terms[[i]]$simCode
+  }
+
+  on.exit(for (i in seq_len(nSimcodes)) {
+      object$obj$env$data$terms[[i]]$simCode = originalSimcodes[[i]]
+    }, add = TRUE)
 
 
   # user-specified (as before)

--- a/DHARMa/R/compatibility.R
+++ b/DHARMa/R/compatibility.R
@@ -645,6 +645,15 @@ getSimulations.glmmTMB <- function (object, nsim = 1, simulateREs = c("condition
 
   out = NULL
 
+  # fixes #538 (restore simCode of model object)
+  originalSimcodes = sapply(seq_along(object$obj$env$data$terms),
+                             function(i) object$obj$env$data$terms[[i]]$simCode)
+
+  on.exit(for (i in seq_along(object$obj$env$data$terms)) {
+      object$obj$env$data$terms[[i]]$simCode = originalSimcodes[i]
+    })
+
+
   # user-specified (as before)
   if(simulateREs == "user-specified") {
     out = simulate(object, nsim = nsim, ...)

--- a/DHARMa/R/compatibility.R
+++ b/DHARMa/R/compatibility.R
@@ -656,7 +656,7 @@ getSimulations.glmmTMB <- function (object, nsim = 1, simulateREs = c("condition
   on.exit(for (i in seq_len(nSimcodes)) {
       object$obj$env$data$terms[[i]]$simCode = originalSimcodes[[i]]
     }, add = TRUE)
-
+  #end restore simcodes
 
   # user-specified (as before)
   if(simulateREs == "user-specified") {


### PR DESCRIPTION
restore the original simcodes of a glmmTMB model after creating simulations from it with DHARMa. fixes issue #538. note that there can be multiple simcodes, one for each random effect (or covariance term). @melina-leite feel free to adjust the code if you find it can be done in a shorter/more elegant way 